### PR TITLE
Document names were wrong

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -177,12 +177,12 @@
       This specification relies on several other underlying specifications. 
       </p> 
       <dl> 
-        <dt>Payment Request Document Architecture</dt>
+        <dt>Payment Request Architecture</dt>
         <dd>The terms <dfn data-lt="payment method|payment methods">Payment Method</dfn>,
         <dfn data-lt="payment app|payment apps">Payment App</dfn>, and <dfn>Payment Transaction
         Message Specification</dfn> are defined by the Payment Request Architecture document
         [[PAYMENTARCH]].</dd>
-        <dt>Payment Request Document Architecture</dt>
+        <dt>Payment Method Identifiers Specification</dt>
         <dd>The term <dfn data-lt="payment method identifier|payment method identifiers">Payment
         Method Identifier</dfn> is defined by the Payment Method Identifiers specification
         [[!METHODIDENTIFIERS]].</dd>


### PR DESCRIPTION
The document names had changed and/or been copy / pasted incorrectly.
